### PR TITLE
Breadcrumbs: fix styles when hover on links. It will be better when you move breadcrumbs after main menu line

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -28,7 +28,7 @@ h6 {
   .navbar-brand, .navbar-nav > li > a{
   color: white;
     &:hover{
-      color: blue;
+      color: white;
     }
   }
 }
@@ -163,8 +163,7 @@ form {
   background: #e1e3ec;
   min-height: 94vh;
   margin-top: 6vh;
-  padding: 0 3%;
-
+  padding: 60px 3%;
   h1 {
     text-align: center;
   }
@@ -239,11 +238,14 @@ td {
 }
 
 .breadcrumb {
-  color:white;
+  color:black;
   a {
-    color:white;
+    color:black;
     text-decoration: none;
     }
+  margin: 20px 0 0 100px;
+  background: #e1e3ec;
+  font-size: 1.2em;
 }
 
 .progress{

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,7 @@
 class Admin::UsersController < ApplicationController
   before_action :authenticate_user!
   before_action :check_admin
+  add_breadcrumb "users", :admin_users_path
 
   def index
     @users = params[:waiting_approval] ? User.waiting_approval : User.all

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,7 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-  add_breadcrumb "Aid-Interview", :new_user_session_path
-  add_breadcrumb "admin", :admin_users_path, :if => :admin_controller?
+  add_breadcrumb "Home", :authenticated_root_path
 
   def admin_controller?
     self.class.name =~ /^Admin(::|Controller)/

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,8 +1,6 @@
 nav.navbar.navbar-default.navbar-fixed-top.topnav[role="navigation"]
   .container
     .navbar-header
-      .navbar-brand.topnav.breadcrumb
-        = render_breadcrumbs separator: " / "
     #bs-example-navbar-collapse-1.collapse.navbar-collapse
       ul.nav.navbar-nav.navbar-right
         li
@@ -24,3 +22,6 @@ nav.navbar.navbar-default.navbar-fixed-top.topnav[role="navigation"]
         - else
           li
             = link_to('Login', new_user_session_path)
+- if user_signed_in?
+  .navbar-brand.topnav.breadcrumb
+    = render_breadcrumbs separator: " > "


### PR DESCRIPTION
https://trello.com/c/YRgp0aPf/53-breadcrumbs-fix-styles-when-hover-on-links-it-will-be-better-when-you-move-breadcrumbs-after-main-menu-line

Screen: http://www.awesomescreenshot.com/image/866105/604f22eea38dbad83291b69a4487c7c8

code review:
- [ ] @CHILL99 
- [ ] @DimaSmagulov 
- [ ] @krisberry 
- [ ] @natalya5 
- [x] @oleg08 
- [ ] @OrestF 
- [x] @vvs79 

2nd lvl review:

- [x] @Kmalynss
- [ ] @serhiym 
- [ ] @ruba-ruba